### PR TITLE
fix: registry

### DIFF
--- a/.kontinuous/env/prod/templates/check-newsletter.cronjob.yaml
+++ b/.kontinuous/env/prod/templates/check-newsletter.cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             fsGroup: 1000
             runAsNonRoot: true
           containers:
-            - image: ghcr.io/socialgouv/recosante/api:{{ .Values.global.imageTag }}
+            - image: "{{ .Values.global.registry }}/recosante/api:{{ .Values.global.imageTag }}"
               imagePullPolicy: IfNotPresent
               name: recosante-check-newsletter
               command:


### PR DESCRIPTION
correction image docker du cronjob check-newsletter

l'image est maintenant Ok mais ca échoue encore avec :

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/util/_collections.py", line 1008, in __call__
    return self.registry[key]
KeyError: <greenlet.greenlet object at 0x7f36e38fa4c0 (otid=0x7f36e38e84b0) current active started main>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/code/check_newsletter.py", line 14, in <module>
    if (count := NewsletterDB.query.filter(NewsletterDB.date==date.today()).count()) < THRESHOLD:
  File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 552, in __get__
    return type.query_class(mapper, session=self.sa.session())
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/scoping.py", line 47, in __call__
    sess = self.registry()
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/util/_collections.py", line 1010, in __call__
    return self.registry.setdefault(key, self.createfunc())
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 4276, in __call__
    return self.class_(**local_kw)
  File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 174, in __init__
    self.app = app = db.get_app()
  File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 1042, in get_app
    raise RuntimeError(
RuntimeError: No application found. Either work inside a view function or push an application context. See http://flask-sqlalchemy.pocoo.org/contexts/.
```