### PR TITLE
chore: deactivate all cronjobs

### DIFF
--- a/api-node/src/cronjobs/utils.ts
+++ b/api-node/src/cronjobs/utils.ts
@@ -49,6 +49,16 @@ export async function launchCronJob(
         active: false,
       },
     });
+    // cleanup old cronjob still active
+    await prisma.cronJob.updateMany({
+      where: {
+        name,
+        active: true,
+      },
+      data: {
+        active: false,
+      },
+    });
     return true;
   } catch (cronError: any) {
     capture(cronError, { level: 'error', extra: { name } });


### PR DESCRIPTION
NOTE: beaucoup de cronjobs ne passent jamais au status `active === FALSE`
avant de merger cette PR - SI il faut la merger - il faut d'abord que je regarde pourquoi ces crons ne finissent pas