### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,14 @@ name: 🔖 Release
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 env:
   GIT_AUTHOR_EMAIL: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
   GIT_AUTHOR_NAME: ${{ secrets.SOCIALGROOVYBOT_NAME }}
   GIT_COMMITTER_EMAIL: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
   GIT_COMMITTER_NAME: ${{ secrets.SOCIALGROOVYBOT_NAME }}
-  GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
 
 jobs:
   release:
@@ -20,6 +22,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -42,6 +51,8 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Semantic Release
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           export PATH="$(pwd)/.github/bin/:$PATH"
           yarn semantic-release


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.